### PR TITLE
Fix: add support for Kotlin data classes without PersistenceConstructor

### DIFF
--- a/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
+++ b/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
@@ -1,17 +1,25 @@
 package com.infobip.spring.data.common;
 
 import com.google.common.base.CaseFormat;
-import com.querydsl.core.types.*;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
 import com.querydsl.sql.RelationalPath;
 import com.querydsl.sql.RelationalPathBase;
 import org.springframework.core.ResolvableType;
-import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.model.PreferredConstructorDiscoverer;
 import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.util.ReflectionUtils;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -92,20 +100,13 @@ public class QuerydslExpressionFactory {
 
     @Nullable
     private Constructor<?> getConstructor(Class<?> type) {
-        Constructor<?>[] declaredConstructors = type.getDeclaredConstructors();
-        Constructor<?> persistenceConstructor = Arrays.stream(declaredConstructors)
-                                                      .filter(constructor -> constructor.isAnnotationPresent(
-                                                              PersistenceConstructor.class))
-                                                      .findAny()
-                                                      .orElse(null);
+        PreferredConstructor<?, ?> preferredConstructor = PreferredConstructorDiscoverer.discover(type);
 
-        if (Objects.nonNull(persistenceConstructor)) {
-            return persistenceConstructor;
+        if (preferredConstructor == null) {
+            return null;
         }
 
-        return Arrays.stream(declaredConstructors)
-                     .max(Comparator.comparingInt(Constructor::getParameterCount))
-                     .orElse(null);
+        return preferredConstructor.getConstructor();
     }
 
     public RelationalPathBase<?> getRelationalPathBaseFromQueryRepositoryClass(Class<?> repositoryInterface) {

--- a/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
+++ b/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
@@ -1,9 +1,7 @@
 package com.infobip.spring.data.common;
 
 import com.google.common.base.CaseFormat;
-import com.querydsl.core.types.ConstructorExpression;
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.*;
 import com.querydsl.sql.RelationalPath;
 import com.querydsl.sql.RelationalPathBase;
 import org.springframework.core.ResolvableType;
@@ -13,13 +11,8 @@ import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.util.ReflectionUtils;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.lang.reflect.*;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/NoArgsEntity.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/NoArgsEntity.java
@@ -2,6 +2,7 @@ package com.infobip.spring.data.jdbc;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 
 @Getter
 @EqualsAndHashCode
@@ -22,6 +23,7 @@ public class NoArgsEntity {
         this.value = null;
     }
 
+    @PersistenceConstructor
     public NoArgsEntity(Long id, String value) {
         this.id = id;
         this.value = value;


### PR DESCRIPTION
When using a Kotlin data class without `PersistenceConstructor`, it picks the incorrect internal Kotlin constructor which leads to errors.

This improvement uses `PreferredConstructorDiscoverer` from Spring Data Common to find the preferred constructor, which supports Kotlin ([source](https://github.com/spring-projects/spring-data-commons/blob/main/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java)).