### PR TITLE
add count method nullsafe in ReactiveQuerydslR2dbcPredicateExecutor

### DIFF
--- a/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/ReactiveQuerydslR2dbcPredicateExecutor.java
+++ b/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/ReactiveQuerydslR2dbcPredicateExecutor.java
@@ -92,11 +92,17 @@ public class ReactiveQuerydslR2dbcPredicateExecutor<T> implements ReactiveQueryd
 
     @Override
     public Mono<Long> count(Predicate predicate) {
+        
         var count = ((SimpleExpression<?>) constructorExpression.getArgs().get(0)).count();
+
         var sqlQuery = sqlQueryFactory.query()
                                       .select(count)
-                                      .where(predicate)
                                       .from(path);
+
+        if (predicate != null) {
+            sqlQuery.where(predicate);
+        }
+
         return query(sqlQuery).one();
     }
 


### PR DESCRIPTION
Added code to refactor into code that uses the count method flexibly.