### PR TITLE
[r2dbc] Apply `R2dbcCoverter` to `ConstantImpl` value in `where` clause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,11 +173,23 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-plugin.version}</version>
+					<configuration>
+						<argLine>
+							--add-opens=java.base/java.lang=ALL-UNNAMED
+							--add-opens=java.base/java.util=ALL-UNNAMED
+						</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
 					<version>${maven-failsafe-plugin.version}</version>
+					<configuration>
+						<argLine>
+							--add-opens=java.base/java.lang=ALL-UNNAMED
+							--add-opens=java.base/java.util=ALL-UNNAMED
+						</argLine>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
I guess many people define some properties of classes mapped with tables as `enum`.

When selecting columns defined as enum, there is no problem because `EntityRowMapper` using `R2dbcConverter` executes simple conversions and user defined conversions (registered via `r2dbcCustomConversions()` of `AbstractR2dbcConfiguration`).

However, when using the columns with the `where` clause like `where(user.status.eq(UserStatus.ONLINE)`, problems occur. The generated query not only apply `Converter`, but also doesn't enclose the enum value with quotation marks (ex> `... where ... user.status = ONLINE`), thus it usually cause db exceptions like `Unknown column 'ONLINE' in 'where clause'`.

If this library supports those conversions, it will be very useful.

I don't think my implementation is not the best one, so please give me advice if you have better idea.

And... I want to do similar things for `having` clause, but sadly `QueryMetadata` of QueryDSL doesn't have `clearHaving()` method. So I handled only `where` clause, for now.