### PR TITLE
Refactor Change Null Check to Optional Class

### DIFF
--- a/infobip-spring-data-jdbc-annotation-processor-common/src/main/java/com/infobip/spring/data/jdbc/annotation/processor/CustomExtendedTypeFactory.java
+++ b/infobip-spring-data-jdbc-annotation-processor-common/src/main/java/com/infobip/spring/data/jdbc/annotation/processor/CustomExtendedTypeFactory.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.base.CaseFormat;
@@ -65,7 +64,7 @@ public class CustomExtendedTypeFactory extends ExtendedTypeFactory {
         var element = types.asElement(typeMirror);
         var entityType = super.getEntityType(typeMirror, deep);
         var embeddedlessProperties =
-                entityType.getProperties()
+                Objects.requireNonNull(entityType).getProperties()
                           .stream()
                           .flatMap(property -> {
                               if (Embeddeds.isEmbedded(configuration, element, property)) {
@@ -74,12 +73,12 @@ public class CustomExtendedTypeFactory extends ExtendedTypeFactory {
 
                               return Stream.of(property);
                           })
-                          .collect(Collectors.toList());
+                          .toList();
         entityType.getProperties().clear();
         entityType.getProperties().addAll(embeddedlessProperties);
         entityType.getPropertyNames().clear();
         entityType.getPropertyNames()
-                  .addAll(embeddedlessProperties.stream().map(Property::getName).collect(Collectors.toList()));
+                  .addAll(embeddedlessProperties.stream().map(Property::getName).toList());
         updateModel(element, entityType);
         return entityType;
     }

--- a/infobip-spring-data-jdbc-querydsl/src/main/java/com/infobip/spring/data/jdbc/AggregateReferenceType.java
+++ b/infobip-spring-data-jdbc-querydsl/src/main/java/com/infobip/spring/data/jdbc/AggregateReferenceType.java
@@ -4,6 +4,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.querydsl.sql.types.Type;
@@ -18,7 +19,7 @@ public class AggregateReferenceType implements Type<AggregateReference> {
 
     @Override
     public String getLiteral(AggregateReference value) {
-        return Optional.ofNullable(value).map(AggregateReference::getId).map(Object::toString).orElse(null);
+        return Objects.requireNonNull(Optional.of(value).map(AggregateReference::getId).map(Object::toString).orElse(null));
     }
 
     @Override

--- a/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/QuerydslParameterBinder.java
+++ b/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/QuerydslParameterBinder.java
@@ -19,12 +19,7 @@ class QuerydslParameterBinder {
     }
 
     private boolean resolve(SQLTemplates sqlTemplates) {
-
-        if(sqlTemplates instanceof MySQLTemplates) {
-            return true;
-        }
-
-        return false;
+        return sqlTemplates instanceof MySQLTemplates;
     }
 
     DatabaseClient.GenericExecuteSpec bind(DatabaseClient databaseClient, List<Object> bindings, String sql) {


### PR DESCRIPTION
hello @lpandzic 
 
Refactored code for clearer exception handling. 
Using the Optional class provides clear null handling and exception handling benefits. 

You can also enjoy the following benefits: 

1. Express your intentions clearly
2. Consistent null handling
3.Prevent NullPointerException (NPE)
4. Better method chaining
5. Provides various functions
6. Improved readability
7. Functional programming style