### PR TITLE
Fix runtime support for @Embedded.Empty and @Embedded.Nullable on composite @Id fields

### DIFF
--- a/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
+++ b/infobip-spring-data-common/src/main/java/com/infobip/spring/data/common/QuerydslExpressionFactory.java
@@ -138,12 +138,12 @@ public class QuerydslExpressionFactory {
     private Optional<Field> getEmbeddedField(Class<?> type, Parameter parameter) {
         return Stream.of(type.getDeclaredFields())
                      .filter(field -> field.getName().equals(parameter.getName()))
-                     .filter(field -> field.isAnnotationPresent(Embedded.class))
+                     .filter(field -> Objects.nonNull(AnnotationUtils.findAnnotation(field, Embedded.class)))
                      .findAny();
     }
 
     private String getEmbeddedPrefix(Field field) {
-        var embedded = field.getAnnotation(Embedded.class);
+        var embedded = AnnotationUtils.findAnnotation(field, Embedded.class);
         return embedded != null ? embedded.prefix() : "";
     }
 
@@ -209,7 +209,7 @@ public class QuerydslExpressionFactory {
     private Optional<Class<?>> getEmbeddedType(Class<?> type, Parameter parameter) {
         return Stream.of(type.getDeclaredFields())
                      .filter(field -> field.getName().equals(parameter.getName()))
-                     .filter(field -> field.isAnnotationPresent(Embedded.class))
+                     .filter(field -> Objects.nonNull(AnnotationUtils.findAnnotation(field, Embedded.class)))
                      .<Class<?>>map(Field::getType)
                      .findAny();
     }

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyId.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyId.java
@@ -1,0 +1,42 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.time.Instant;
+
+import lombok.With;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("PersonWithEmbeddedId")
+public record PersonWithEmbeddedEmptyId(
+
+    @With
+    @Id
+    @Embedded.Empty
+    FirstAndLastName id,
+
+    Instant createdAt,
+
+    @With
+    @Transient
+    boolean newEntity
+) implements Persistable<FirstAndLastName> {
+
+    @PersistenceCreator
+    public PersonWithEmbeddedEmptyId(FirstAndLastName id, Instant createdAt) {
+        this(id, createdAt, false);
+    }
+
+    @Override
+    public boolean isNew() {
+        return newEntity;
+    }
+
+    @Override
+    public FirstAndLastName getId() {
+        return id;
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyIdRepository.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyIdRepository.java
@@ -1,0 +1,11 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.util.List;
+
+import com.infobip.spring.data.jdbc.QuerydslJdbcRepository;
+
+public interface PersonWithEmbeddedEmptyIdRepository
+        extends QuerydslJdbcRepository<PersonWithEmbeddedEmptyId, FirstAndLastName> {
+
+    List<PersonWithEmbeddedEmptyId> findByIdFirstName(String firstName);
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyIdRepositoryTest.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedEmptyIdRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import static com.infobip.spring.data.jdbc.embedded.QPersonWithEmbeddedEmptyId.personWithEmbeddedEmptyId;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.infobip.spring.data.jdbc.TestBase;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@AllArgsConstructor
+public class PersonWithEmbeddedEmptyIdRepositoryTest extends TestBase {
+
+    private static final TimeZone oldTimeZone = TimeZone.getDefault();
+
+    private final PersonWithEmbeddedEmptyIdRepository repository;
+
+    @BeforeAll
+    void setupTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+    }
+
+    @AfterAll
+    void cleanUpTimeZone() {
+        TimeZone.setDefault(oldTimeZone);
+    }
+
+    @Test
+    void shouldSave() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+
+        // when
+        var actual = repository.save(new PersonWithEmbeddedEmptyId(id, BEGINNING_OF_2021, true));
+
+        then(actual.id()).isEqualTo(id);
+        then(actual.createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindById() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+        givenSaved("John", "Doe");
+
+        // when
+        var actual = repository.findById(id);
+
+        then(actual).isPresent();
+        then(actual.get().id()).isEqualTo(id);
+        then(actual.get().createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindAllWithPredicate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        List<PersonWithEmbeddedEmptyId> actual = repository.findAll(
+            personWithEmbeddedEmptyId.firstName.eq("John"));
+
+        then(actual).hasSize(1);
+        then(actual.get(0).id()).isEqualTo(new FirstAndLastName("John", "Doe"));
+    }
+
+    @Test
+    void shouldFindByIdFirstName() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("John", "Roe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findByIdFirstName("John");
+
+        then(actual).hasSize(2);
+        then(actual).extracting(e -> e.id().lastName())
+                   .containsExactlyInAnyOrder("Doe", "Roe");
+    }
+
+    @Test
+    void shouldUpdate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        Long actual = repository.update(query -> query
+            .set(personWithEmbeddedEmptyId.firstName, "Jonathan")
+            .where(personWithEmbeddedEmptyId.firstName.eq("John"))
+            .execute());
+
+        then(actual).isEqualTo(1);
+        then(repository.findAll()).extracting(e -> e.id().firstName())
+                                  .containsExactlyInAnyOrder("Jonathan", "Jane");
+    }
+
+    @Test
+    void shouldDelete() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.deleteWhere(personWithEmbeddedEmptyId.firstName.like("John%"));
+
+        then(repository.findAll()).hasSize(1);
+        then(repository.findAll().get(0).id().firstName()).isEqualTo("Jane");
+        then(actual).isEqualTo(1L);
+    }
+
+    private PersonWithEmbeddedEmptyId givenSaved(String firstName, String lastName) {
+        return repository.save(
+            new PersonWithEmbeddedEmptyId(new FirstAndLastName(firstName, lastName), BEGINNING_OF_2021, true));
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedId.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedId.java
@@ -1,0 +1,42 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.time.Instant;
+
+import lombok.With;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("PersonWithEmbeddedId")
+public record PersonWithEmbeddedId(
+
+    @With
+    @Id
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    FirstAndLastName id,
+
+    Instant createdAt,
+
+    @With
+    @Transient
+    boolean newEntity
+) implements Persistable<FirstAndLastName> {
+
+    @PersistenceCreator
+    public PersonWithEmbeddedId(FirstAndLastName id, Instant createdAt) {
+        this(id, createdAt, false);
+    }
+
+    @Override
+    public boolean isNew() {
+        return newEntity;
+    }
+
+    @Override
+    public FirstAndLastName getId() {
+        return id;
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedIdRepository.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedIdRepository.java
@@ -1,0 +1,16 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.infobip.spring.data.jdbc.QuerydslJdbcRepository;
+
+public interface PersonWithEmbeddedIdRepository
+        extends QuerydslJdbcRepository<PersonWithEmbeddedId, FirstAndLastName> {
+
+    List<PersonWithEmbeddedId> findByIdFirstName(String firstName);
+
+    List<PersonWithEmbeddedId> findByIdLastName(String lastName);
+
+    Optional<PersonWithEmbeddedId> findByIdFirstNameAndIdLastName(String firstName, String lastName);
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedIdRepositoryTest.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedIdRepositoryTest.java
@@ -1,0 +1,189 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import static com.infobip.spring.data.jdbc.embedded.QPersonWithEmbeddedId.personWithEmbeddedId;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.infobip.spring.data.jdbc.TestBase;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@AllArgsConstructor
+public class PersonWithEmbeddedIdRepositoryTest extends TestBase {
+
+    private static final TimeZone oldTimeZone = TimeZone.getDefault();
+
+    private final PersonWithEmbeddedIdRepository repository;
+
+    @BeforeAll
+    void setupTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+    }
+
+    @AfterAll
+    void cleanUpTimeZone() {
+        TimeZone.setDefault(oldTimeZone);
+    }
+
+    @Test
+    void shouldSave() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+
+        // when
+        var actual = repository.save(new PersonWithEmbeddedId(id, BEGINNING_OF_2021, true));
+
+        then(actual.id()).isEqualTo(id);
+        then(actual.createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindById() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+        givenSaved("John", "Doe");
+
+        // when
+        var actual = repository.findById(id);
+
+        then(actual).isPresent();
+        then(actual.get().id()).isEqualTo(id);
+        then(actual.get().createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindAll() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findAll();
+
+        then(actual).hasSize(2);
+        then(actual).extracting(PersonWithEmbeddedId::id)
+                   .containsExactlyInAnyOrder(
+                       new FirstAndLastName("John", "Doe"),
+                       new FirstAndLastName("Jane", "Doe"));
+    }
+
+    @Test
+    void shouldFindAllWithPredicate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        List<PersonWithEmbeddedId> actual = repository.findAll(
+            personWithEmbeddedId.firstName.eq("John"));
+
+        then(actual).hasSize(1);
+        then(actual.get(0).id()).isEqualTo(new FirstAndLastName("John", "Doe"));
+    }
+
+    @Test
+    void shouldFindByIdFirstName() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("John", "Roe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findByIdFirstName("John");
+
+        then(actual).hasSize(2);
+        then(actual).extracting(e -> e.id().lastName())
+                   .containsExactlyInAnyOrder("Doe", "Roe");
+    }
+
+    @Test
+    void shouldFindByIdLastName() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("John", "Roe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findByIdLastName("Doe");
+
+        then(actual).hasSize(2);
+        then(actual).extracting(e -> e.id().firstName())
+                   .containsExactlyInAnyOrder("John", "Jane");
+    }
+
+    @Test
+    void shouldFindByIdFirstNameAndIdLastName() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("John", "Roe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findByIdFirstNameAndIdLastName("John", "Doe");
+
+        then(actual).isPresent();
+        then(actual.get().id()).isEqualTo(new FirstAndLastName("John", "Doe"));
+    }
+
+    @Test
+    void shouldFindByIdFirstNameAndIdLastNameNotFound() {
+
+        // given
+        givenSaved("John", "Doe");
+
+        // when
+        var actual = repository.findByIdFirstNameAndIdLastName("Jane", "Doe");
+
+        then(actual).isEmpty();
+    }
+
+    @Test
+    void shouldUpdate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        Long actual = repository.update(query -> query
+            .set(personWithEmbeddedId.firstName, "Jonathan")
+            .where(personWithEmbeddedId.firstName.eq("John"))
+            .execute());
+
+        then(actual).isEqualTo(1);
+        then(repository.findAll()).extracting(e -> e.id().firstName())
+                                  .containsExactlyInAnyOrder("Jonathan", "Jane");
+    }
+
+    @Test
+    void shouldDelete() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.deleteWhere(personWithEmbeddedId.firstName.like("John%"));
+
+        then(repository.findAll()).hasSize(1);
+        then(repository.findAll().get(0).id().firstName()).isEqualTo("Jane");
+        then(actual).isEqualTo(1L);
+    }
+
+    private PersonWithEmbeddedId givenSaved(String firstName, String lastName) {
+        return repository.save(
+            new PersonWithEmbeddedId(new FirstAndLastName(firstName, lastName), BEGINNING_OF_2021, true));
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableId.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableId.java
@@ -1,0 +1,42 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.time.Instant;
+
+import lombok.With;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("PersonWithEmbeddedId")
+public record PersonWithEmbeddedNullableId(
+
+    @With
+    @Id
+    @Embedded.Nullable
+    FirstAndLastName id,
+
+    Instant createdAt,
+
+    @With
+    @Transient
+    boolean newEntity
+) implements Persistable<FirstAndLastName> {
+
+    @PersistenceCreator
+    public PersonWithEmbeddedNullableId(FirstAndLastName id, Instant createdAt) {
+        this(id, createdAt, false);
+    }
+
+    @Override
+    public boolean isNew() {
+        return newEntity;
+    }
+
+    @Override
+    public FirstAndLastName getId() {
+        return id;
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableIdRepository.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableIdRepository.java
@@ -1,0 +1,11 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import java.util.List;
+
+import com.infobip.spring.data.jdbc.QuerydslJdbcRepository;
+
+public interface PersonWithEmbeddedNullableIdRepository
+        extends QuerydslJdbcRepository<PersonWithEmbeddedNullableId, FirstAndLastName> {
+
+    List<PersonWithEmbeddedNullableId> findByIdFirstName(String firstName);
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableIdRepositoryTest.java
+++ b/infobip-spring-data-jdbc-querydsl/src/test/java/com/infobip/spring/data/jdbc/embedded/PersonWithEmbeddedNullableIdRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.infobip.spring.data.jdbc.embedded;
+
+import static com.infobip.spring.data.jdbc.embedded.QPersonWithEmbeddedNullableId.personWithEmbeddedNullableId;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.infobip.spring.data.jdbc.TestBase;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@AllArgsConstructor
+public class PersonWithEmbeddedNullableIdRepositoryTest extends TestBase {
+
+    private static final TimeZone oldTimeZone = TimeZone.getDefault();
+
+    private final PersonWithEmbeddedNullableIdRepository repository;
+
+    @BeforeAll
+    void setupTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+    }
+
+    @AfterAll
+    void cleanUpTimeZone() {
+        TimeZone.setDefault(oldTimeZone);
+    }
+
+    @Test
+    void shouldSave() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+
+        // when
+        var actual = repository.save(new PersonWithEmbeddedNullableId(id, BEGINNING_OF_2021, true));
+
+        then(actual.id()).isEqualTo(id);
+        then(actual.createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindById() {
+
+        // given
+        var id = new FirstAndLastName("John", "Doe");
+        givenSaved("John", "Doe");
+
+        // when
+        var actual = repository.findById(id);
+
+        then(actual).isPresent();
+        then(actual.get().id()).isEqualTo(id);
+        then(actual.get().createdAt()).isEqualTo(BEGINNING_OF_2021);
+    }
+
+    @Test
+    void shouldFindAllWithPredicate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        List<PersonWithEmbeddedNullableId> actual = repository.findAll(
+            personWithEmbeddedNullableId.firstName.eq("John"));
+
+        then(actual).hasSize(1);
+        then(actual.get(0).id()).isEqualTo(new FirstAndLastName("John", "Doe"));
+    }
+
+    @Test
+    void shouldFindByIdFirstName() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("John", "Roe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.findByIdFirstName("John");
+
+        then(actual).hasSize(2);
+        then(actual).extracting(e -> e.id().lastName())
+                   .containsExactlyInAnyOrder("Doe", "Roe");
+    }
+
+    @Test
+    void shouldUpdate() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        Long actual = repository.update(query -> query
+            .set(personWithEmbeddedNullableId.firstName, "Jonathan")
+            .where(personWithEmbeddedNullableId.firstName.eq("John"))
+            .execute());
+
+        then(actual).isEqualTo(1);
+        then(repository.findAll()).extracting(e -> e.id().firstName())
+                                  .containsExactlyInAnyOrder("Jonathan", "Jane");
+    }
+
+    @Test
+    void shouldDelete() {
+
+        // given
+        givenSaved("John", "Doe");
+        givenSaved("Jane", "Doe");
+
+        // when
+        var actual = repository.deleteWhere(personWithEmbeddedNullableId.firstName.like("John%"));
+
+        then(repository.findAll()).hasSize(1);
+        then(repository.findAll().get(0).id().firstName()).isEqualTo("Jane");
+        then(actual).isEqualTo(1L);
+    }
+
+    private PersonWithEmbeddedNullableId givenSaved(String firstName, String lastName) {
+        return repository.save(
+            new PersonWithEmbeddedNullableId(new FirstAndLastName(firstName, lastName), BEGINNING_OF_2021, true));
+    }
+}

--- a/infobip-spring-data-jdbc-querydsl/src/test/resources/db/migration/V1_0_0__base_schema.sql
+++ b/infobip-spring-data-jdbc-querydsl/src/test/resources/db/migration/V1_0_0__base_schema.sql
@@ -15,6 +15,14 @@ CREATE TABLE PersonSettings
     CONSTRAINT FK_PersonSettings_PersonId FOREIGN KEY (PersonId) REFERENCES Person (Id) ON DELETE CASCADE
 );
 
+CREATE TABLE PersonWithEmbeddedId
+(
+    FirstName NVARCHAR(20) NOT NULL,
+    LastName  NVARCHAR(20) NOT NULL,
+    CreatedAt DATETIME2,
+    CONSTRAINT PK_PersonWithEmbeddedId PRIMARY KEY (FirstName, LastName)
+);
+
 CREATE TABLE NoArgsEntity
 (
     Id    BIGINT IDENTITY,


### PR DESCRIPTION
## Summary

Fixes the runtime failure reported in [#118 (comment)](https://github.com/infobip/infobip-spring-data-querydsl/issues/118#issuecomment-4387365661).

When `@Embedded.Empty` or `@Embedded.Nullable` is used on a composite `@Id` field, `QuerydslExpressionFactory` fails with `Failed to match parameter id to QClass column`. This only occurs when the embedded field is the `@Id` — the constructor parameter name (`id`) differs from the flattened column names (`firstName`, `lastName`), so the factory must resolve it as an embedded type. Non-ID embedded fields (e.g. `firstAndLastName`) match directly by parameter name and don't hit this code path.

Root cause: `field.isAnnotationPresent(Embedded.class)` cannot detect `@Embedded.Empty`/`@Embedded.Nullable` because they are meta-annotations rather than direct `@Embedded` instances. Spring's `AnnotationUtils.findAnnotation()` traverses the meta-annotation hierarchy correctly.

## Changes

- Replaced `field.isAnnotationPresent()` / `field.getAnnotation()` with `AnnotationUtils.findAnnotation()` in `QuerydslExpressionFactory` (3 methods)
- Added test entities and tests for `@Embedded`, `@Embedded.Empty`, and `@Embedded.Nullable` on composite `@Id` fields
